### PR TITLE
Speed up polygonization

### DIFF
--- a/mask_to_polygons/processing/buildings.py
+++ b/mask_to_polygons/processing/buildings.py
@@ -67,7 +67,8 @@ def get_polygons(mask,
             if building.sum() >= min_area:
                 dilated = cv2.morphologyEx(
                     building, cv2.MORPH_DILATE, kernel, iterations=1)
-                shapes = rasterio.features.shapes(dilated, transform=transform)
+                shapes = rasterio.features.shapes(
+                    dilated, transform=transform, mask=mask == 1)
                 shapes = filter(lambda ab: ab[1] == 1, shapes)
                 shapes = list(shapes)
                 if len(shapes) > 0:

--- a/mask_to_polygons/processing/polygons.py
+++ b/mask_to_polygons/processing/polygons.py
@@ -4,7 +4,7 @@ import rasterio.features
 
 def get_polygons(mask, transform):
     polygons = []
-    shapes = rasterio.features.shapes(mask, transform=transform)
+    shapes = rasterio.features.shapes(mask, mask=mask == 1, transform=transform)
     shapes = filter(lambda ab: ab[1] == 1, shapes)
     shapes = list(shapes)
 

--- a/mask_to_polygons/vectorification.py
+++ b/mask_to_polygons/vectorification.py
@@ -42,11 +42,17 @@ def geometries_from_mask(mask,
                          min_area=None,
                          width_factor=0.5,
                          thickness=0.001):
+    transform_fn = None
     if isinstance(transform, rasterio.transform.Affine):
         pass
     elif isinstance(transform, str):
         with rasterio.open(transform, 'r') as dataset:
             transform = dataset.transform
+    elif callable(transform):
+        # Transform can be function of form f(x, y) which is assumed to convert from
+        # pixel coordinates to (lat, lng)
+        transform_fn = transform
+        transform = rasterio.transform.IDENTITY
 
     if mode == 'polygons':
         polys = polygons.get_polygons(mask, transform)
@@ -55,6 +61,14 @@ def geometries_from_mask(mask,
                                        min_area, width_factor, thickness)
     else:
         raise Exception()
+
+    if transform_fn:
+        new_polys = []
+        for p in polys:
+            p = shapely.geometry.shape(p)
+            p = shapely.ops.transform(lambda x, y, z=None: transform_fn(x, y), p)
+            new_polys.append(shapely.geometry.mapping(p))
+        polys = new_polys
 
     return polys
 

--- a/mask_to_polygons/vectorification.py
+++ b/mask_to_polygons/vectorification.py
@@ -92,7 +92,7 @@ def geojson_from_mask(mask,
     return geojson.dumps(FeatureCollection(features))
 
 
-def shapley_from_mask(mask,
+def shapeley_from_mask(mask,
                       transform,
                       mode='polygon',
                       min_aspect_ratio=1.618,


### PR DESCRIPTION
This PR uses the mask argument to shapely.features.shapes to ignore background pixels. This speeds up processing a 3000x3000 image by 25x, and makes it so 30k x 30k image can be processed in less than a minute.

This also adds support for a custom transform function which enables producing GeoJSON in lat/lng format (rather than the imagery CRS).