### PR TITLE
Upgraded from OpenCV 3.4.* to 4.1.*

### DIFF
--- a/mask_to_polygons/processing/buildings.py
+++ b/mask_to_polygons/processing/buildings.py
@@ -6,7 +6,7 @@ import rasterio.features
 
 
 def get_rectangle(buildings):
-    _, contours, _ = cv2.findContours(buildings, cv2.RETR_EXTERNAL,
+   contours, _ = cv2.findContours(buildings, cv2.RETR_EXTERNAL,
                                       cv2.CHAIN_APPROX_SIMPLE)
     if len(contours) > 0:
         rectangle = cv2.minAreaRect(contours[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Shapely==1.6.*
-opencv-python==3.4.*
+opencv-python==4.1.*
 numpy>=1.0.0
 rasterio>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license='Apache License 2.0',
     install_requires=[
         'Shapely==1.6.*',
-        'opencv-python==3.4.*',
+        'opencv-python==4.1.*',
         'numpy>=1.0.0',
         'rasterio>=1.0.0',
         'geojson>=2.4.0',


### PR DESCRIPTION
Upgraded to openCV 4.1.* for use in rastervision to solve [this dependency error](https://github.com/azavea/raster-vision/pull/851#issuecomment-555014155). I checked all the cv2 functions in this repo via Python help(cv2.function) and compared them with the implementation in 3.4.*. Only the cv2.findContours function seems to have changed. I changed the code accordingly.