### PR TITLE
Avoid loading OpenCV when not needed

### DIFF
--- a/mask_to_polygons/vectorification.py
+++ b/mask_to_polygons/vectorification.py
@@ -6,9 +6,6 @@ import shapely
 import shapely.geometry
 from geojson import FeatureCollection
 
-from mask_to_polygons.processing import buildings
-from mask_to_polygons.processing import polygons
-
 
 def mask_from_geotiff(mask_filename):
     with rasterio.open(mask_filename, 'r') as dataset:
@@ -55,8 +52,10 @@ def geometries_from_mask(mask,
         transform = rasterio.transform.IDENTITY
 
     if mode == 'polygons':
+        from mask_to_polygons.processing import polygons
         polys = polygons.get_polygons(mask, transform)
     elif mode == 'buildings':
+        from mask_to_polygons.processing import buildings
         polys = buildings.get_polygons(mask, transform, min_aspect_ratio,
                                        min_area, width_factor, thickness)
     else:


### PR DESCRIPTION
```python
from mask_to_polygons.processing import buildings
```
causes `cv2` to be imported, and for that to succeed, you need a number of other packages/libraries installed. Example errors: 
```bash
from .cv2 import * ImportError: libgthread-2.0.so.0: cannot open shared object file: No such file or directory
from .cv2 import * ImportError: libGL-2.0.so.0: cannot open shared object file: No such file or directory
from .cv2 import * ImportError: libSM-2.0.so.0: cannot open shared object file: No such file or directory
```

This is too much hassle if one is only interested in using `polygons` and not `buildings`.

This PR moves the above import statement, so that it is only run if the user wants to use `buildings`. It does the same for `polygons` for consistency.